### PR TITLE
Return early if start or stop are null

### DIFF
--- a/src/VirtualList/index.js
+++ b/src/VirtualList/index.js
@@ -143,6 +143,9 @@ export default class VirtualizedList {
       offset,
       overscanCount,
     });
+
+    if (start == null || stop == null) return
+
     const fragment = document.createDocumentFragment();
 
     for (let index = start; index <= stop; index++) {


### PR DESCRIPTION
Hey hey!

This patch should make sure that we don't throw when `getVisibleRange` returns a empty object:

https://github.com/clauderic/virtualized-list/blob/d519d57de207d73685a0230b9449e1d491d56353/src/VirtualList/SizeAndPositionManager.js#L121

Instead we just return early. Not sure if there is a better way to handle this case.