### PR TITLE
Fix range end when overscan

### DIFF
--- a/src/VirtualList/SizeAndPositionManager.js
+++ b/src/VirtualList/SizeAndPositionManager.js
@@ -134,7 +134,7 @@ export default class SizeAndPositionManager {
 
     if (overscanCount) {
       start = Math.max(0, start - overscanCount);
-      stop = Math.min(stop + overscanCount, this._itemCount);
+      stop = Math.min(stop + overscanCount, this._itemCount - 1);
     }
 
     return {

--- a/tests/SizeAndPositionManager.test.js
+++ b/tests/SizeAndPositionManager.test.js
@@ -410,6 +410,17 @@ describe('SizeAndPositionManager', () => {
       expect(start).toEqual(95);
       expect(stop).toEqual(99);
     });
+
+    it("should return a visible range of items for the end of the list", () => {
+      const {sizeAndPositionManager} = getItemSizeAndPositionManager();
+      const {start, stop} = sizeAndPositionManager.getVisibleRange({
+        containerSize: 50,
+        offset: 950,
+        overscanCount: 5,
+      });
+      expect(start).toEqual(90);
+      expect(stop).toEqual(99);
+    });
   });
 
   describe('resetItem', () => {


### PR DESCRIPTION
This fixes a bug in the end value of a range when `overscanCount` is provided.
It's an off by one error where the end exceeds the list limit.
E.g. if `itemCount` is 100, range end should be 99 for the last possible range.
But if `overscanCount` is provided, range end returns 100, which is not a valid index.
I've added a regression test that clarifies the scenario for the bug and confirms the fix.